### PR TITLE
Update metadata to match reality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["dependencies", "optional-dependencies"]
 [tool.setuptools]
 # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
 #       CHANGE `py_modules = ['...']` TO `packages = ['...']`
-py-modules = ["cedargrove_temperaturetools"]
+packages = ["cedargrove_temperaturetools"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
This is needed so that we can rely on the metadata in https://github.com/adafruit/circuitpython-build-tools/pull/101

Please make a new tagged release after incorporating this change.

If you don't think you'll be able to deal with this in a timely fashion, please let me know.